### PR TITLE
refactor: add ytsearch prefix and update lava-queue

### DIFF
--- a/5-music-player-lavalink/package.json
+++ b/5-music-player-lavalink/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@discordx/importer": "^1.1.10",
     "@discordx/lava-player": "^1.0.11",
-    "@discordx/lava-queue": "^1.0.5",
+    "@discordx/lava-queue": "^1.1.0",
     "@discordx/pagination": "^3.0.0",
     "discord.js": "^14.3.0",
     "discordx": "^11.1.10",

--- a/5-music-player-lavalink/src/commands/v3.cmd.ts
+++ b/5-music-player-lavalink/src/commands/v3.cmd.ts
@@ -143,7 +143,7 @@ export class MusicPlayer {
     if (type === "URL") {
       response = await queue.enqueue(input);
     } else {
-      const searchResponse = await queue.search(input);
+      const searchResponse = await queue.search(`ytsearch:${input}`);
       const track = searchResponse.tracks[0];
       if (!track) {
         interaction.followUp("> no search result");


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
This PR will add the `ytsearch:` prefix to the search method according to the latest update of `@discordx/lava-queue`

- discordx
- @discordx/templates