### PR TITLE
fix: lava-queue bugs with livestreams

### DIFF
--- a/5-music-player-lavalink/src/commands/queue.ts
+++ b/5-music-player-lavalink/src/commands/queue.ts
@@ -154,8 +154,17 @@ export class MusicQueue extends Queue {
 
     const bar = (this.isPlaying ? "▶️" : "⏸️") + " " + progressString;
     const currentTime = this.fromMS(timeNow);
-    const endTime = this.fromMS(timeTotal);
-    const spacing = bar.length - currentTime.length - endTime.length;
+
+    let endTime: string;
+    let spacing: number;
+    if (currentTrack.info.isStream) {
+      endTime = "Livestream";
+      spacing = 8.5;
+    } else {
+      endTime = this.fromMS(timeTotal);
+      spacing = bar.length - currentTime.length - endTime.length;
+    }
+
     const time =
       "`" + currentTime + " ".repeat(spacing * 3 - 2) + endTime + "`";
 
@@ -231,12 +240,20 @@ export class MusicQueue extends Queue {
 
       const queue = this.tracks
         .slice(currentPage * 10, currentPage * 10 + 10)
-        .map(
-          (track, index1) =>
+        .map((track, index1) => {
+          let endTime: string;
+          if (track.info.isStream) {
+            endTime = "Livestream";
+          } else {
+            endTime = this.fromMS(track.info.length);
+          }
+
+          return (
             `${currentPage * 10 + index1 + 1}. [${track.info.title}](<${
               track.info.uri
-            }>)` + ` (${this.fromMS(track.info.length)})`
-        )
+            }>)` + ` (${endTime})`
+          );
+        })
         .join("\n\n");
 
       return { content: `${current}\n\n${queue}` };

--- a/5-music-player-lavalink/src/commands/queue.ts
+++ b/5-music-player-lavalink/src/commands/queue.ts
@@ -241,12 +241,9 @@ export class MusicQueue extends Queue {
       const queue = this.tracks
         .slice(currentPage * 10, currentPage * 10 + 10)
         .map((track, index1) => {
-          let endTime: string;
-          if (track.info.isStream) {
-            endTime = "Livestream";
-          } else {
-            endTime = this.fromMS(track.info.length);
-          }
+          const endTime = track.info.isStream
+            ? "Livestream"
+            : this.fromMS(track.info.length);
 
           return (
             `${currentPage * 10 + index1 + 1}. [${track.info.title}](<${


### PR DESCRIPTION
This PR fixes some bugs I found some bugs when playing livestreams from youtube or twitch with lava-queue.

## First bug

The first one happens when you queue a livestream, which throws an error and stops the app

### Error

![Error](https://cdn.discordapp.com/attachments/895860691385348096/1014225767342817290/unknown.png)

### [Where it happens](https://github.com/discordx-ts/templates/blob/main/5-music-player-lavalink/src/commands/queue.ts#L157)

![Where it happens](https://cdn.discordapp.com/attachments/895860691385348096/1014225643933806602/unknown.png)

### Variable values

![Variable values](https://cdn.discordapp.com/attachments/895860691385348096/1014224961411497984/unknown.png)

This error happens because the `endTime` from streams is a pretty large number, which makes the `spacing` become a
negative value and then throw the error. To solve it, we just need to set spacing to a different positive value.

## Second bug

The second bug happens on the controls because of the `endTime` from livestreams

### Control bug

![Bug](https://cdn.discordapp.com/attachments/895860691385348096/1014310563112828928/unknown.png)

As livestreams don't have an end, I think the `endTime` should be just `livestream`

### Solving both the bugs

![Solution](https://cdn.discordapp.com/attachments/895860691385348096/1014314035803590686/unknown.png)

![Solution](https://cdn.discordapp.com/attachments/895860691385348096/1014317089642795129/unknown.png)

## Third bug

The third bug I found is the same as the second one, but it happens when viewing the queue and it contains a livestream.

### Queue bug

![Queue Bug](https://cdn.discordapp.com/attachments/895860691385348096/1014315205263630416/unknown.png)

### [Where it happens](https://github.com/discordx-ts/templates/blob/main/5-music-player-lavalink/src/commands/queue.ts#L232)

![Where it happens](https://cdn.discordapp.com/attachments/895860691385348096/1014316284168650842/unknown.png)

To solve it, we should check if it is a livestream and set the time to someting else

### Solution

![Solution](https://cdn.discordapp.com/attachments/895860691385348096/1014358605635539015/unknown.png)

![Solution](https://cdn.discordapp.com/attachments/895860691385348096/1014317811620921444/unknown.png)