### PR TITLE
refactor: add can't seek check

### DIFF
--- a/5-music-player-lavalink/src/commands/v3.cmd.ts
+++ b/5-music-player-lavalink/src/commands/v3.cmd.ts
@@ -209,9 +209,7 @@ export class MusicPlayer {
     }
 
     if (!queue.currentTrack.info.isSeekable) {
-      await interaction.followUp(
-        "> this track can't be seeked"
-      );
+      await interaction.followUp("> this track can't be seeked");
       return;
     }
 

--- a/5-music-player-lavalink/src/commands/v3.cmd.ts
+++ b/5-music-player-lavalink/src/commands/v3.cmd.ts
@@ -208,6 +208,13 @@ export class MusicPlayer {
       return;
     }
 
+    if (!queue.currentTrack.info.isSeekable) {
+      await interaction.followUp(
+        "> this track can't be seeked"
+      );
+      return;
+    }
+
     if (seconds * 1000 > queue.currentTrack.info.length) {
       queue.playNext();
       interaction.followUp("> skipped the track instead");


### PR DESCRIPTION

This PR adds a check to verify if the track can be seeked, because livestreams can't.

### [Where it happens](https://github.com/discordx-ts/templates/blob/main/5-music-player-lavalink/src/commands/v3.cmd.ts#L193)

### Solution

![Solution](https://cdn.discordapp.com/attachments/895860691385348096/1014321572217110548/unknown.png)