### PR TITLE
refactor: update deprecated string menu interaction type

### DIFF
--- a/1-starter/src/commands/menu.ts
+++ b/1-starter/src/commands/menu.ts
@@ -1,9 +1,9 @@
 import type {
   CommandInteraction,
   MessageActionRowComponentBuilder,
-  SelectMenuInteraction,
+  StringSelectMenuInteraction,
 } from "discord.js";
-import { ActionRowBuilder, SelectMenuBuilder } from "discord.js";
+import { ActionRowBuilder, StringSelectMenuBuilder } from "discord.js";
 import { Discord, SelectMenuComponent, Slash } from "discordx";
 
 const roles = [
@@ -15,7 +15,7 @@ const roles = [
 @Discord()
 export class Example {
   @SelectMenuComponent({ id: "role-menu" })
-  async handle(interaction: SelectMenuInteraction): Promise<unknown> {
+  async handle(interaction: StringSelectMenuInteraction): Promise<unknown> {
     await interaction.deferReply();
 
     // extract selected value by member
@@ -39,7 +39,7 @@ export class Example {
     await interaction.deferReply();
 
     // create menu for roles
-    const menu = new SelectMenuBuilder()
+    const menu = new StringSelectMenuBuilder()
       .addOptions(roles)
       .setCustomId("role-menu");
 

--- a/2-starter-with-api/src/commands/menu.ts
+++ b/2-starter-with-api/src/commands/menu.ts
@@ -1,9 +1,9 @@
 import type {
   CommandInteraction,
   MessageActionRowComponentBuilder,
-  SelectMenuInteraction,
+  StringSelectMenuInteraction,
 } from "discord.js";
-import { ActionRowBuilder, SelectMenuBuilder } from "discord.js";
+import { ActionRowBuilder, StringSelectMenuBuilder } from "discord.js";
 import { Discord, SelectMenuComponent, Slash } from "discordx";
 
 const roles = [
@@ -15,7 +15,7 @@ const roles = [
 @Discord()
 export class Example {
   @SelectMenuComponent({ id: "role-menu" })
-  async handle(interaction: SelectMenuInteraction): Promise<unknown> {
+  async handle(interaction: StringSelectMenuInteraction): Promise<unknown> {
     await interaction.deferReply();
 
     // extract selected value by member
@@ -39,7 +39,7 @@ export class Example {
     await interaction.deferReply();
 
     // create menu for roles
-    const menu = new SelectMenuBuilder()
+    const menu = new StringSelectMenuBuilder()
       .addOptions(roles)
       .setCustomId("role-menu");
 


### PR DESCRIPTION
After creating a new project using the "starter" template, I noticed a few issues which I've addressed in this PR.

1. `npm run dev` failing due to unknown extension ".ts"
![image](https://github.com/discordx-ts/templates/assets/47653736/8544bc2c-1b15-43f7-ba5a-cacb1651cf30)

2. deprecation warning on menu imports
![image](https://github.com/discordx-ts/templates/assets/47653736/e5a3bc8f-35db-462b-8075-523037bfbecc)
![image](https://github.com/discordx-ts/templates/assets/47653736/c57156f3-cad7-40e4-b2c6-b1c065a963dd)


The deprecation was easy to fix as the new version of discord.js uses `StringSelectMenuBuilder` and `StringSelectMenuInteraction` instead of `SelectMenuBuilder` and `SelectMenuInteraction` respectively.

The "dev" script took some digging but I found a working version.

"ts-node-esm" either isn't installing correctly or has some configuration issues, but a working command that achieves the same result is "node --loader ts-node/esm src/main.ts". I've made these changes and now when installing, it should be working as intended


Edit:

The 2 commits made to change the "dev" script have been deleted