### PR TITLE
fix: watch script not restarting on change

### DIFF
--- a/1-starter/package.json
+++ b/1-starter/package.json
@@ -10,7 +10,7 @@
     "build:changelog": "npx @discordx/changelog --src src",
     "dev": "node --loader ts-node/esm/transpile-only src/main.ts",
     "start": "node build/main.js",
-    "watch": "nodemon --exec npm run dev"
+    "watch": "nodemon --exec npm run dev --watch src --ext ts"
   },
   "dependencies": {
     "@discordx/importer": "^1.3.0",

--- a/2-starter-with-api/package.json
+++ b/2-starter-with-api/package.json
@@ -10,7 +10,7 @@
     "build:changelog": "npx @discordx/changelog --src src",
     "dev": "node --loader ts-node/esm/transpile-only src/main.ts",
     "start": "node build/main.js",
-    "watch": "nodemon --exec npm run dev"
+    "watch": "nodemon --exec npm run dev --watch src --ext ts"
   },
   "dependencies": {
     "@discordx/importer": "^1.3.0",

--- a/3-blank/package.json
+++ b/3-blank/package.json
@@ -10,7 +10,7 @@
     "build:changelog": "npx @discordx/changelog --src src",
     "dev": "node --loader ts-node/esm/transpile-only src/main.ts",
     "start": "node build/main.js",
-    "watch": "nodemon --exec npm run dev"
+    "watch": "nodemon --exec npm run dev --watch src --ext ts"
   },
   "dependencies": {
     "@discordx/importer": "^1.3.0",

--- a/4-music-player-ytdl/package.json
+++ b/4-music-player-ytdl/package.json
@@ -9,7 +9,7 @@
     "build:changelog": "npx @discordx/changelog --src src",
     "dev": "node --loader ts-node/esm/transpile-only src/main.ts",
     "start": "node build/main.js",
-    "watch": "nodemon --exec npm run dev"
+    "watch": "nodemon --exec npm run dev --watch src --ext ts"
   },
   "repository": {
     "type": "git",

--- a/5-music-player-lavalink/package.json
+++ b/5-music-player-lavalink/package.json
@@ -10,7 +10,7 @@
     "build:changelog": "npx @discordx/changelog --src src",
     "dev": "node --loader ts-node/esm/transpile-only src/main.ts",
     "start": "node build/main.js",
-    "watch": "nodemon --exec npm run dev"
+    "watch": "nodemon --exec npm run dev --watch src --ext ts"
   },
   "dependencies": {
     "@discordx/importer": "^1.3.0",

--- a/6-koa-server/package.json
+++ b/6-koa-server/package.json
@@ -10,7 +10,7 @@
     "build:changelog": "npx @discordx/changelog --src src",
     "dev": "node --loader ts-node/esm/transpile-only src/main.ts",
     "start": "node build/main.js",
-    "watch": "nodemon --exec npm run dev"
+    "watch": "nodemon --exec npm run dev --watch src --ext ts"
   },
   "dependencies": {
     "@discordx/importer": "^1.3.0",


### PR DESCRIPTION
This updates the nodemon execution command to watch the 'src' directory and the TypeScript files. The new command is 'nodemon --exec npm run dev --watch src --ext ts'. This change makes sure that the server restarts whenever there are changes in the TypeScript files in the 'src' directory.